### PR TITLE
Change set-output to environment file

### DIFF
--- a/.github/workflows/on_pull_request_linter.yml
+++ b/.github/workflows/on_pull_request_linter.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on: pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Lint allowed branch names
+        uses: lekterable/branchlint-action@1.2.0
+        with:
+          allowed: |
+            /^(.+:)?bugfix/.+/i
+            /^(.+:)?docs?/.+/i
+            /^(.+:)?feature/.+/i
+            /^(.+:)?major/.+/i
+            /^(.+:)?misc/.+/i
+      -
+        name: Block fixup/squash commits
+        uses: xt0rted/block-autosquash-commits-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,6 +1,11 @@
 name: Unit Tests
 
-on: push
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  push:
+    branches: [main]
+    tags-ignore: ["**"]
 
 env:
   GO_VERSION_FILE: "go.mod"
@@ -11,20 +16,53 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      -
+      - 
         name: Checkout
         uses: actions/checkout@v3
-      -
+      - 
         uses: actions/setup-go@v3
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           check-latest: ${{ env.CHECK_LATEST }}
-      -
+      - 
         name: Pull dependencies
         run: go mod vendor
-      -
+      - 
         name: Linter
         run: make lint
-      -
+      - 
         name: Unit tests
         run: make test
+      - 
+        name: Vulnerability scan
+        run: make vulncheck
+  
+  version:
+    name: Version
+    concurrency: tagging
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Calculate semver tag
+        id: semver-tag
+        uses: snapfi/semver-action@main
+      - 
+        name: Create tag
+        uses: actions/github-script@v6
+        if: steps.semver-tag.outputs.semver_tag != ''
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.semver-tag.outputs.semver_tag }}",
+              sha: context.sha
+            })

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ endif
 lint: install-linter
 	golangci-lint run ./...
 
+.PHONY: vulncheck
+vulncheck:
+	go install golang.org/x/vuln/cmd/govulncheck@latest
+	govulncheck ./...
+
 .PHONY: test
 test:
 	$(GOTEST) -race -covermode=atomic -coverprofile=coverage.out ./...

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ These are the prefixes we expect when `auto` bump:
 
 ### Scenarios
 
+In case of `force_prelease` is `true`, it will always create a pre-release version. Otherwise, it will create a final version.
+
 #### Auto Bump
 
 - Not a valid source branch prefix - Increments prerelease version.
@@ -89,21 +91,22 @@ Uses `auto` bump strategy to calculate the next semantic version.
 
 ## Inputs
 
-| parameter           | required | description                                                                      | default     |
-| ---                 | ---      | ---                                                                              | ---         |
-| bump                |          | Bump strategy for semantic versioning. Can be `auto`, `major`, `minor`, `patch`. | auto        |
-| base_version        |          | Version to use as base for the generation, skips version bumps.                  |             |
-| prefix              |          | Prefix used to prepend the final version.                                        | v           |
-| prerelease_id       |          | Text representing the prerelease identifier.                                     | pre         |
-| branch_name         |          | The branch name.                                                                 | main        |
-| repo_dir            |          | The repository path.                                                             | current dir |
-| debug               |          | Enables debug mode.                                                              | false       |
+| parameter | required | description | default |
+| --- | --- | --- | --- |
+| bump | false | Bump strategy for semantic versioning. Can be `auto`, `major`, `minor`, `patch`. | auto |
+| base_version | false | Version to use as base for the generation, skips version bumps. | |
+| prefix | false | Prefix used to prepend the final version.| v |
+| prerelease_id | false | Text representing the prerelease identifier. | pre |
+| force_prerelease | false | Force the generation of a prerelease version. Usually used in trunk-based development where the main branch is always a prerelease version. | false |
+| branch_name | false | The branch name. | main  |
+| repo_dir | false | The repository path. | current dir |
+| debug | false | Enables debug mode. | false |
 
 ## Outpus
 
 | parameter     | description                                      |
 | ---           | ---                                              |
-| semver_tag    | The calculdated semantic version.                |
-| is_prerelease | True if calculated tag is prerelease.           |
+| semver_tag    | The calculated semantic version.                 |
+| is_prerelease | True if calculated tag is prerelease.            |
 | previous_tag  | The tag used to calculate next semantic version. |
 | ancestor_tag  | The ancestor tag based on specific pattern.      |

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Text representing the prerelease identifier'
     default: 'pre'
     required: false
+  force_prerelease:
+    description: 'Force the generation of a prerelease version. Usually used in trunk-based development where the main branch is always a prerelease version'
+    default: 'false'
+    required: false
   branch_name:
     description: 'The branch name'
     default: 'main'
@@ -52,6 +56,7 @@ runs:
     - ${{ inputs.base_version }}
     - ${{ inputs.prefix }}
     - ${{ inputs.prerelease_id }}
+    - ${{ inputs.force_prerelease }}
     - ${{ inputs.branch_name }}
     - ${{ inputs.repo_dir }}
     - ${{ inputs.debug }}

--- a/cmd/generate/generate_internal_test.go
+++ b/cmd/generate/generate_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetermineBumpStrategy(t *testing.T) {
@@ -25,7 +26,7 @@ func TestDetermineBumpStrategy(t *testing.T) {
 			SourceBranch:    "doc/some",
 			DestBranch:      "main",
 			Bump:            "auto",
-			ExpectedMethod:  "build",
+			ExpectedMethod:  "",
 			ExpectedVersion: "",
 		},
 		"source branch feature, dest branch main and auto bump": {
@@ -46,13 +47,8 @@ func TestDetermineBumpStrategy(t *testing.T) {
 			SourceBranch:    "misc/some",
 			DestBranch:      "main",
 			Bump:            "auto",
-			ExpectedMethod:  "build",
+			ExpectedMethod:  "",
 			ExpectedVersion: "",
-		},
-		"not a valid source branch prefix and auto bump": {
-			SourceBranch:   "some-branch",
-			Bump:           "auto",
-			ExpectedMethod: "build",
 		},
 		"patch bump": {
 			Bump:           "patch",
@@ -70,10 +66,17 @@ func TestDetermineBumpStrategy(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			method, version := determineBumpStrategy(test.Bump, test.SourceBranch, test.DestBranch, "main")
+			method, version, err := determineBumpStrategy(test.Bump, test.SourceBranch, test.DestBranch, "main")
+			require.NoError(t, err)
 
 			assert.Equal(t, test.ExpectedMethod, method)
 			assert.Equal(t, test.ExpectedVersion, version)
 		})
 	}
+}
+
+func TestDetermineBumpStrategy_InvalidSource(t *testing.T) {
+	_, _, err := determineBumpStrategy("auto", "some-branch", "main", "main")
+
+	assert.EqualError(t, err, "invalid bump strategy")
 }

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -24,11 +24,12 @@ func TestTag(t *testing.T) {
 			CurrentBranch: "main",
 			SourceBranch:  "major/some",
 			Params: generate.Params{
-				CommitSha:    "81918ffc",
-				Bump:         "auto",
-				Prefix:       "v",
-				PrereleaseID: "alpha",
-				BranchName:   "main",
+				CommitSha:       "81918ffc",
+				Bump:            "auto",
+				Prefix:          "v",
+				PrereleaseID:    "alpha",
+				ForcePrerelease: true,
+				BranchName:      "main",
 			},
 			Result: generate.Result{
 				PreviousTag:  "v0.0.0",
@@ -49,42 +50,19 @@ func TestTag(t *testing.T) {
 				PrereleaseID: "alpha",
 				BranchName:   "main",
 			},
-			Result: generate.Result{
-				PreviousTag:  "v0.2.1-alpha.1",
-				AncestorTag:  "v0.2.0-alpha.1",
-				SemverTag:    "v0.2.1-alpha.2",
-				IsPrerelease: true,
-			},
-		},
-		"doc branch into main when latest tag is equal to ancestor main tag excluding prerelease part": {
-			CurrentBranch: "main",
-			LatestTag:     "v0.2.1",
-			AncestorTag:   "v0.2.1-alpha.2",
-			SourceBranch:  "doc/some",
-			Params: generate.Params{
-				CommitSha:    "81918ffc",
-				Bump:         "auto",
-				Prefix:       "v",
-				PrereleaseID: "alpha",
-				BranchName:   "main",
-			},
-			Result: generate.Result{
-				PreviousTag:  "v0.2.1",
-				AncestorTag:  "v0.2.1-alpha.2",
-				SemverTag:    "v0.2.1-alpha.3",
-				IsPrerelease: true,
-			},
+			Result: generate.Result{},
 		},
 		"feature branch into main": {
 			CurrentBranch: "main",
 			LatestTag:     "v0.2.1",
 			SourceBranch:  "feature/some",
 			Params: generate.Params{
-				CommitSha:    "81918ffc",
-				Bump:         "auto",
-				Prefix:       "v",
-				PrereleaseID: "alpha",
-				BranchName:   "main",
+				CommitSha:       "81918ffc",
+				Bump:            "auto",
+				Prefix:          "v",
+				PrereleaseID:    "alpha",
+				ForcePrerelease: true,
+				BranchName:      "main",
 			},
 			Result: generate.Result{
 				PreviousTag:  "v0.2.1",
@@ -95,16 +73,19 @@ func TestTag(t *testing.T) {
 		"bugfix branch into main": {
 			CurrentBranch: "main",
 			LatestTag:     "v0.2.1",
+			AncestorTag:   "v0.2.1-alpha.2",
 			SourceBranch:  "bugfix/some",
 			Params: generate.Params{
-				CommitSha:    "81918ffc",
-				Bump:         "auto",
-				Prefix:       "v",
-				PrereleaseID: "alpha",
-				BranchName:   "main",
+				CommitSha:       "81918ffc",
+				Bump:            "auto",
+				Prefix:          "v",
+				PrereleaseID:    "alpha",
+				ForcePrerelease: true,
+				BranchName:      "main",
 			},
 			Result: generate.Result{
 				PreviousTag:  "v0.2.1",
+				AncestorTag:  "v0.2.1-alpha.2",
 				SemverTag:    "v0.2.2-alpha.1",
 				IsPrerelease: true,
 			},
@@ -121,11 +102,44 @@ func TestTag(t *testing.T) {
 				PrereleaseID: "alpha",
 				BranchName:   "main",
 			},
+			Result: generate.Result{},
+		},
+		"valid branch into main with with force_prerelease false and with pre-release latest tag": {
+			CurrentBranch: "main",
+			LatestTag:     "v0.2.1-alpha.1",
+			AncestorTag:   "v0.2.0-alpha.1",
+			SourceBranch:  "feature/some",
+			Params: generate.Params{
+				CommitSha:    "81918ffc",
+				Bump:         "auto",
+				Prefix:       "v",
+				PrereleaseID: "alpha",
+				BranchName:   "main",
+			},
 			Result: generate.Result{
 				PreviousTag:  "v0.2.1-alpha.1",
 				AncestorTag:  "v0.2.0-alpha.1",
-				SemverTag:    "v0.2.1-alpha.2",
-				IsPrerelease: true,
+				SemverTag:    "v0.3.0",
+				IsPrerelease: false,
+			},
+		},
+		"valid branch into main with with force_prerelease false": {
+			CurrentBranch: "main",
+			LatestTag:     "v0.2.1",
+			AncestorTag:   "v0.2.0",
+			SourceBranch:  "feature/some",
+			Params: generate.Params{
+				CommitSha:    "81918ffc",
+				Bump:         "auto",
+				Prefix:       "v",
+				PrereleaseID: "alpha",
+				BranchName:   "main",
+			},
+			Result: generate.Result{
+				PreviousTag:  "v0.2.1",
+				AncestorTag:  "v0.2.0",
+				SemverTag:    "v0.3.0",
+				IsPrerelease: false,
 			},
 		},
 		"base version set": {
@@ -133,33 +147,17 @@ func TestTag(t *testing.T) {
 			LatestTag:     "v2.6.19",
 			SourceBranch:  "feature/semver-initial",
 			Params: generate.Params{
-				CommitSha:    "81918ffc",
-				Bump:         "auto",
-				BaseVersion:  newSemVerPtr(t, "4.2.0"),
-				Prefix:       "v",
-				PrereleaseID: "alpha",
-				BranchName:   "main",
+				CommitSha:       "81918ffc",
+				Bump:            "auto",
+				BaseVersion:     newSemVerPtr(t, "4.2.0"),
+				Prefix:          "v",
+				PrereleaseID:    "alpha",
+				ForcePrerelease: true,
+				BranchName:      "main",
 			},
 			Result: generate.Result{
 				PreviousTag:  "v2.6.19",
 				SemverTag:    "v4.3.0-alpha.1",
-				IsPrerelease: true,
-			},
-		},
-		"invalid branch name": {
-			CurrentBranch: "main",
-			LatestTag:     "v2.6.19-alpha.1",
-			SourceBranch:  "semver-initial",
-			Params: generate.Params{
-				CommitSha:    "81918ffc",
-				Bump:         "auto",
-				Prefix:       "v",
-				PrereleaseID: "alpha",
-				BranchName:   "main",
-			},
-			Result: generate.Result{
-				PreviousTag:  "v2.6.19-alpha.1",
-				SemverTag:    "v2.6.19-alpha.2",
 				IsPrerelease: true,
 			},
 		},
@@ -168,11 +166,12 @@ func TestTag(t *testing.T) {
 			LatestTag:     "v2.6.19-alpha.1",
 			SourceBranch:  "semver-initial",
 			Params: generate.Params{
-				CommitSha:    "81918ffc",
-				Bump:         "major",
-				Prefix:       "v",
-				PrereleaseID: "alpha",
-				BranchName:   "main",
+				CommitSha:       "81918ffc",
+				Bump:            "major",
+				Prefix:          "v",
+				PrereleaseID:    "alpha",
+				ForcePrerelease: true,
+				BranchName:      "main",
 			},
 			Result: generate.Result{
 				PreviousTag:  "v2.6.19-alpha.1",
@@ -185,11 +184,12 @@ func TestTag(t *testing.T) {
 			LatestTag:     "v2.6.19-alpha.1",
 			SourceBranch:  "semver-initial",
 			Params: generate.Params{
-				CommitSha:    "81918ffc",
-				Bump:         "minor",
-				Prefix:       "v",
-				PrereleaseID: "alpha",
-				BranchName:   "main",
+				CommitSha:       "81918ffc",
+				Bump:            "minor",
+				Prefix:          "v",
+				PrereleaseID:    "alpha",
+				ForcePrerelease: true,
+				BranchName:      "main",
 			},
 			Result: generate.Result{
 				PreviousTag:  "v2.6.19-alpha.1",
@@ -202,11 +202,12 @@ func TestTag(t *testing.T) {
 			LatestTag:     "v2.6.19-alpha.1",
 			SourceBranch:  "semver-initial",
 			Params: generate.Params{
-				CommitSha:    "81918ffc",
-				Bump:         "patch",
-				Prefix:       "v",
-				PrereleaseID: "alpha",
-				BranchName:   "main",
+				CommitSha:       "81918ffc",
+				Bump:            "patch",
+				Prefix:          "v",
+				PrereleaseID:    "alpha",
+				ForcePrerelease: true,
+				BranchName:      "main",
 			},
 			Result: generate.Result{
 				PreviousTag:  "v2.6.19-alpha.1",
@@ -233,6 +234,31 @@ func TestTag(t *testing.T) {
 			assert.Equal(t, test.Result, result)
 		})
 	}
+}
+
+func TestTag_InvalidBranchName(t *testing.T) {
+	params := generate.Params{
+		CommitSha:    "81918ffc",
+		Bump:         "auto",
+		Prefix:       "v",
+		PrereleaseID: "alpha",
+		BranchName:   "main",
+	}
+
+	gc := initGitClientMock(
+		t,
+		"v2.6.19-alpha.1",
+		"",
+		"main",
+		"semver-initial",
+		"81918ffc",
+	)
+
+	result, err := generate.Tag(params, gc)
+
+	assert.EqualError(t, err, "failed to determine bump strategy: invalid bump strategy")
+
+	assert.Empty(t, result)
 }
 
 func TestTag_IsNotRepo(t *testing.T) {

--- a/cmd/generate/params.go
+++ b/cmd/generate/params.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	//nolint
+	// nolint
 	commitShaRegex = regexp.MustCompile(`\b[0-9a-f]{5,40}\b`)
 	// nolint
 	validBumpStrategies = []string{"auto", "major", "minor", "patch"}
@@ -20,14 +20,15 @@ var (
 
 // Params contains semver generate command parameters.
 type Params struct {
-	CommitSha    string
-	RepoDir      string
-	Bump         string
-	BaseVersion  *semver.Version
-	Prefix       string
-	PrereleaseID string
-	BranchName   string
-	Debug        bool
+	CommitSha       string
+	RepoDir         string
+	Bump            string
+	BaseVersion     *semver.Version
+	Prefix          string
+	PrereleaseID    string
+	ForcePrerelease bool
+	BranchName      string
+	Debug           bool
 }
 
 // LoadParams loads semver generate config params.
@@ -101,15 +102,27 @@ func LoadParams() (Params, error) {
 		prereleaseID = prereleaseIDStr
 	}
 
+	var forcePrerelease bool
+
+	if forcePrereleaseStr := actions.GetInput("force_prerelease"); forcePrereleaseStr != "" {
+		parsed, err := strconv.ParseBool(forcePrereleaseStr)
+		if err != nil {
+			return Params{}, fmt.Errorf("invalid force_prerelease argument: %s", forcePrereleaseStr)
+		}
+
+		forcePrerelease = parsed
+	}
+
 	return Params{
-		CommitSha:    commitSha,
-		RepoDir:      repoDir,
-		Bump:         bump,
-		BaseVersion:  baseVersion,
-		Prefix:       prefix,
-		PrereleaseID: prereleaseID,
-		BranchName:   branchName,
-		Debug:        debug,
+		CommitSha:       commitSha,
+		RepoDir:         repoDir,
+		Bump:            bump,
+		BaseVersion:     baseVersion,
+		Prefix:          prefix,
+		PrereleaseID:    prereleaseID,
+		ForcePrerelease: forcePrerelease,
+		BranchName:      branchName,
+		Debug:           debug,
 	}, nil
 }
 
@@ -131,12 +144,14 @@ func (p Params) String() string {
 
 	return fmt.Sprintf(
 		"commit sha: %q, bump: %q, base version: %q, prefix: %q,"+
-			" prerelease id: %q, branch name: %q, repo dir: %q, debug: %t\n",
+			" prerelease id: %q, force prerelease: %t, branch name: %q,"+
+			" repo dir: %q, debug: %t\n",
 		p.CommitSha,
 		p.Bump,
 		baseVersion,
 		p.Prefix,
 		p.PrereleaseID,
+		p.ForcePrerelease,
 		p.BranchName,
 		p.RepoDir,
 		p.Debug,

--- a/cmd/generate/params_test.go
+++ b/cmd/generate/params_test.go
@@ -12,9 +12,16 @@ import (
 )
 
 func TestLoadParams_Prefix(t *testing.T) {
-	os.Setenv("INPUT_PREFIX", "v")
+	os.Setenv("INPUT_PREFIX", "ver")
 	defer os.Unsetenv("INPUT_PREFIX")
 
+	params, err := generate.LoadParams()
+	require.NoError(t, err)
+
+	assert.Equal(t, "ver", params.Prefix)
+}
+
+func TestLoadParams_Prefix_Default(t *testing.T) {
 	params, err := generate.LoadParams()
 	require.NoError(t, err)
 
@@ -31,10 +38,41 @@ func TestLoadParams_PrereleaseID(t *testing.T) {
 	assert.Equal(t, "alpha", params.PrereleaseID)
 }
 
+func TestLoadParams_PrereleaseID_Default(t *testing.T) {
+	params, err := generate.LoadParams()
+	require.NoError(t, err)
+
+	assert.Equal(t, "pre", params.PrereleaseID)
+}
+
+func TestLoadParams_ForcePrerelease(t *testing.T) {
+	os.Setenv("INPUT_FORCE_PRERELEASE", "true")
+	defer os.Unsetenv("INPUT_FORCE_PRERELEASE")
+
+	params, err := generate.LoadParams()
+	require.NoError(t, err)
+
+	assert.True(t, params.ForcePrerelease)
+}
+
+func TestLoadParams_ForcePrerelease_Default(t *testing.T) {
+	params, err := generate.LoadParams()
+	require.NoError(t, err)
+
+	assert.False(t, params.ForcePrerelease)
+}
+
 func TestLoadParams_BranchName(t *testing.T) {
-	os.Setenv("INPUT_BRANCH_NAME", "main")
+	os.Setenv("INPUT_BRANCH_NAME", "master")
 	defer os.Unsetenv("INPUT_BRANCH_NAME")
 
+	params, err := generate.LoadParams()
+	require.NoError(t, err)
+
+	assert.Equal(t, "master", params.BranchName)
+}
+
+func TestLoadParams_BranchName_Default(t *testing.T) {
 	params, err := generate.LoadParams()
 	require.NoError(t, err)
 
@@ -67,6 +105,13 @@ func TestLoadParams_RepoDir(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "/var/tmp/wakatime-cli", params.RepoDir)
+}
+
+func TestLoadParams_RepoDir_Default(t *testing.T) {
+	params, err := generate.LoadParams()
+	require.NoError(t, err)
+
+	assert.Equal(t, ".", params.RepoDir)
 }
 
 func TestLoadParams_Bump(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/apex/log v1.9.0
 	github.com/blang/semver/v4 v4.0.0
+	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
+	uuid "github.com/nu7hatch/gouuid"
 )
 
 func main() {
@@ -20,21 +21,71 @@ func main() {
 		os.Exit(1)
 	}
 
+	outputFilepath := os.Getenv("GITHUB_OUTPUT")
+
 	// Print previous tag.
 	log.Infof("PREVIOUS_TAG: %s", result.PreviousTag)
-	fmt.Printf("::set-output name=PREVIOUS_TAG::%s\n", result.PreviousTag)
+
+	if err := setOutput(outputFilepath, "PREVIOUS_TAG", result.PreviousTag); err != nil {
+		log.Errorf("%s\n", err)
+
+		os.Exit(1)
+	}
 
 	// Print ancestor tag.
 	log.Infof("ANCESTOR_TAG: %s", result.AncestorTag)
-	fmt.Printf("::set-output name=ANCESTOR_TAG::%s\n", result.AncestorTag)
+
+	if err := setOutput(outputFilepath, "ANCESTOR_TAG", result.AncestorTag); err != nil {
+		log.Errorf("%s\n", err)
+
+		os.Exit(1)
+	}
 
 	// Print calculated semver tag.
 	log.Infof("SEMVER_TAG: %s", result.SemverTag)
-	fmt.Printf("::set-output name=SEMVER_TAG::%s\n", result.SemverTag)
+
+	if err := setOutput(outputFilepath, "SEMVER_TAG", result.SemverTag); err != nil {
+		log.Errorf("%s\n", err)
+
+		os.Exit(1)
+	}
 
 	// Print is prerelease.
 	log.Infof("IS_PRERELEASE: %v", result.IsPrerelease)
-	fmt.Printf("::set-output name=IS_PRERELEASE::%v\n", result.IsPrerelease)
 
-	os.Exit(0)
+	if err := setOutput(outputFilepath, "IS_PRERELEASE", fmt.Sprintf("%v", result.IsPrerelease)); err != nil {
+		log.Errorf("%s\n", err)
+
+		os.Exit(1)
+	}
+}
+
+func setOutput(fp, key, value string) error {
+	f, err := os.OpenFile(fp, os.O_APPEND|os.O_WRONLY, 0600) // nolint:gosec
+	if err != nil {
+		return fmt.Errorf("failed to open github output file: %s", err)
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	delimiter := fmt.Sprintf("ghadelimiter_%s", newId())
+
+	if _, err := f.WriteString(fmt.Sprintf("%s<<%s\n%v\n%s\n", key, delimiter, value, delimiter)); err != nil {
+		return fmt.Errorf("failed to write %s to output: %s", key, err)
+	}
+
+	return nil
+}
+
+func newId() string {
+	id, err := uuid.NewV4()
+	if err != nil {
+		log.Errorf("failed to generate delimier uuid: %s\n", err)
+
+		os.Exit(1)
+	}
+
+	return id.String()
 }


### PR DESCRIPTION
This PR changes the way Github Actions reads output from Actions to a shared environment file. It also removes tag generation for `docs/` and `misc/` branch prefixes.